### PR TITLE
Replace cowboy with plug_cowboy

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Opencast.Mixfile do
       {:phoenix_ecto, "~> 3.0-rc"},
       {:postgrex, ">= 0.11.1"},
       {:gettext, "~> 0.9"},
-      {:cowboy, "~> 1.0"},
+      {:plug_cowboy, "~> 1.0"},
       {:ja_serializer, "~> 0.13.0"},
       {:ex_machina, "~> 1.0.2"},
       {:sweet_xml, "~> 0.6.6"},


### PR DESCRIPTION
Fixes

```
** (Mix) Could not start application opencast: Opencast.start(:normal, []) returned an error: shutdown: failed to start child: Opencast.Endpoint
    ** (EXIT) shutdown: failed to start child: Phoenix.Endpoint.Server
        ** (EXIT) "plug_cowboy dependency missing"
```